### PR TITLE
feat: add additional os testing with matrix strategy for all but cloudfront invalidation

### DIFF
--- a/.github/workflows/awscli.yml
+++ b/.github/workflows/awscli.yml
@@ -8,7 +8,10 @@ on:
 jobs:
   awscli:
     name: Execute some awscli invocations
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/awscli.yml
+++ b/.github/workflows/awscli.yml
@@ -4,6 +4,18 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'packages/awscli/**'
+      - 'packages/awscli-core/**'
+      - 'package.json'
+
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'packages/awscli/**'
+      - 'packages/awscli-core/**'
+      - 'package.json'
 
 jobs:
   awscli:

--- a/.github/workflows/cloudfront_invalidate.yml
+++ b/.github/workflows/cloudfront_invalidate.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'packages/cloudfront_invalidate/**'
+      - 'package.json'
 
 jobs:
   cloudfront-invalidate:

--- a/.github/workflows/iam_access_credentials.yaml
+++ b/.github/workflows/iam_access_credentials.yaml
@@ -4,6 +4,16 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'packages/iam_access_credentials/**'
+      - 'package.json'
+
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'packages/iam_access_credentials/**'
+      - 'package.json'
 
 jobs:
   s3-sync:

--- a/.github/workflows/iam_access_credentials.yaml
+++ b/.github/workflows/iam_access_credentials.yaml
@@ -8,7 +8,10 @@ on:
 jobs:
   s3-sync:
     name: Setup IAM access credentials
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/s3_sync.yml
+++ b/.github/workflows/s3_sync.yml
@@ -8,7 +8,10 @@ on:
 jobs:
   s3-sync:
     name: Sync assets to S3
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/s3_sync.yml
+++ b/.github/workflows/s3_sync.yml
@@ -4,6 +4,18 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'packages/s3_sync/**'
+      - 'packages/awscli-core/**'
+      - 'package.json'
+
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'packages/s3_sync/**'
+      - 'packages/awscli-core/**'
+      - 'package.json'
 
 jobs:
   s3-sync:


### PR DESCRIPTION
## Description
- Enable additional os testing

## Motivation and Context
- Currently only ubuntu is tested/validated

## How Has This Been Tested?
- This is a test (or series of tests rather)

## Screenshots (if appropriate):
